### PR TITLE
Break out assignSubValue function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # mapconv
-Golang package for flattening a complex value down to a map of paths to values.
+Golang package for flattening a structured value down to a map of paths to values.
+
+Arrays, maps, and slices recursively produce map keys until terminal values are found.
+
+Terminal values are:
+
+- bool
+- int (and rune, int8, int16, ...)
+- uint (and byte, uint8, uint16, ...)
+- float64 (and float32)
+- string

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,24 @@
+package mapconv
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type unsupportedKindError struct {
+	path string
+	kind reflect.Kind
+}
+
+func (err unsupportedKindError) Error() string {
+	return fmt.Sprintf("mapconv: unsupported value on path (%s) of type (%s)", err.path, err.kind)
+}
+
+type unknownKindError struct {
+	path string
+	kind reflect.Kind
+}
+
+func (err unknownKindError) Error() string {
+	return fmt.Sprintf("mapconv: unknown value on path (%s) of type (%s)", err.path, err.kind)
+}

--- a/mapconv.go
+++ b/mapconv.go
@@ -17,39 +17,12 @@ func ToMap(value interface{}, prefix string) (m map[string]string, err error) {
 		return
 	}
 
-	assignSubValue := func(path string, v reflect.Value) (err error) {
-		switch v.Kind() {
-		case reflect.Bool:
-			m[path] = strconv.FormatBool(v.Bool())
-		case reflect.Float32, reflect.Float64:
-			m[path] = strings.TrimRight(strings.TrimRight(strconv.FormatFloat(v.Float(), 'f', 6, 64), "0"), ".")
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			m[path] = strconv.FormatInt(v.Int(), 10)
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			m[path] = strconv.FormatUint(v.Uint(), 10)
-		case reflect.String:
-			m[path] = v.String()
-		case reflect.Array, reflect.Map, reflect.Slice, reflect.Interface:
-			var subMap map[string]string
-			subMap, err = ToMap(v.Interface(), path)
-			for key, value := range subMap {
-				m[key] = value
-			}
-		case reflect.Invalid, reflect.Chan, reflect.Func, reflect.UnsafePointer, reflect.Complex64, reflect.Complex128:
-			err = fmt.Errorf("mapconv: unsupported values on path (%s) of type (%s)", path, v.Kind())
-		default:
-			err = fmt.Errorf("mapconv: unknown value on path (%s) of type (%s)", path, v.Kind())
-		}
-		return err
-	}
-
 	rv := reflect.ValueOf(value)
 	switch rv.Kind() {
 	case reflect.Map:
 		for _, k := range rv.MapKeys() {
 			path := prefix + `["` + k.String() + `"]`
-			v := rv.MapIndex(k)
-			err = assignSubValue(path, v)
+			err = assignSubValue(m, path, rv.MapIndex(k).Interface())
 			if err != nil {
 				//return
 			}
@@ -57,15 +30,52 @@ func ToMap(value interface{}, prefix string) (m map[string]string, err error) {
 	case reflect.Array, reflect.Slice:
 		for i := 0; i < rv.Len(); i++ {
 			path := prefix + "[" + strconv.Itoa(i+1) + "]"
-			v := rv.Index(i)
-			err = assignSubValue(path, v)
+			err = assignSubValue(m, path, rv.Index(i).Interface())
 			if err != nil {
 				//return
 			}
 		}
 	default:
-		err = assignSubValue(prefix, rv)
+		err = assignSubValue(m, prefix, rv.Interface())
 	}
 
 	return m, err
+}
+
+func assignSubValue(m map[string]string, path string, v interface{}) (err error) {
+	if v, ok := v.(fmt.Stringer); ok {
+		m[path] = v.String()
+		return
+	}
+
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Bool:
+		m[path] = strconv.FormatBool(rv.Bool())
+	case reflect.Float32, reflect.Float64:
+		m[path] = strings.TrimRight(strings.TrimRight(strconv.FormatFloat(rv.Float(), 'f', 6, 64), "0"), ".")
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		m[path] = strconv.FormatInt(rv.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		m[path] = strconv.FormatUint(rv.Uint(), 10)
+	case reflect.String:
+		m[path] = rv.String()
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.Interface:
+		var subMap map[string]string
+		subMap, err = ToMap(rv.Interface(), path)
+		for key, value := range subMap {
+			m[key] = value
+		}
+	case reflect.Invalid, reflect.Chan, reflect.Func, reflect.UnsafePointer, reflect.Complex64, reflect.Complex128:
+		err = unsupportedKindError{
+			path: path,
+			kind: rv.Kind(),
+		}
+	default:
+		err = unknownKindError{
+			path: path,
+			kind: rv.Kind(),
+		}
+	}
+	return err
 }

--- a/mapconv.go
+++ b/mapconv.go
@@ -60,13 +60,13 @@ func assignSubValue(m map[string]string, path string, v interface{}) (err error)
 		m[path] = strconv.FormatUint(rv.Uint(), 10)
 	case reflect.String:
 		m[path] = rv.String()
-	case reflect.Array, reflect.Map, reflect.Slice, reflect.Interface:
+	case reflect.Array, reflect.Map, reflect.Slice:
 		var subMap map[string]string
 		subMap, err = ToMap(rv.Interface(), path)
 		for key, value := range subMap {
 			m[key] = value
 		}
-	case reflect.Invalid, reflect.Chan, reflect.Func, reflect.UnsafePointer, reflect.Complex64, reflect.Complex128:
+	case reflect.Invalid, reflect.Chan, reflect.Func, reflect.UnsafePointer, reflect.Complex64, reflect.Complex128, reflect.Interface:
 		err = unsupportedKindError{
 			path: path,
 			kind: rv.Kind(),


### PR DESCRIPTION
Since "complex" is actually a Go type and it's not supported, I slightly reworded the readme; the supported types are enumerated there.

The `assignSubValue` function is broken out, not assigned to a variable, and could possibly be a candidate for its own unit test in the future.

Errors come from one of two (unexported) types. Calling code can't tell the difference, but future error handling within this package or packages based on it would have an easier time using the error types.
